### PR TITLE
Upper bounded compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,4 +7,4 @@ version = "3.2.3"
 mlpack_jll = "156a7db3-27ba-586e-a86b-f061da4f95ea"
 
 [compat]
-julia = ">= 1.3"
+julia = "1.3"


### PR DESCRIPTION
Just wanted to help with the registration if possible; one of the automerge blockers is non-upper bounded compat. This PR changes the compat for Julia to be the range `[1.3, 2.0)`, i.e. any version semver-compatible with 1.3 (but excluding 2.0 which may contain breaking changes which break this package). That should not be anytime soon anyway.

(In this PR, I use `julia = "1.3"` [which is equivalent](https://julialang.github.io/Pkg.jl/v1/compatibility/) to `julia = "^1.3"`, meaning the interval I wrote above).