### PR TITLE
Add `GC.@preserve`s needed for `ccall`s using `pointer()`

### DIFF
--- a/src/adaboost.jl
+++ b/src/adaboost.jl
@@ -35,14 +35,14 @@ end
 # Serialize a model to the given stream.
 function serializeAdaBoostModel(stream::IO, model::AdaBoostModel)
   buf_len = UInt[0]
-  buf_ptr = ccall((:SerializeAdaBoostModelPtr, adaboostLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, Base.pointer(buf_len))
+  buf_ptr = ccall((:SerializeAdaBoostModelPtr, adaboostLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, pointer(buf_len))
   buf = Base.unsafe_wrap(Vector{UInt8}, buf_ptr, buf_len[1]; own=true)
   write(stream, buf)
 end
 # Deserialize a model from the given stream.
 function deserializeAdaBoostModel(stream::IO)::AdaBoostModel
   buffer = read(stream)
-  AdaBoostModel(ccall((:DeserializeAdaBoostModelPtr, adaboostLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), Base.pointer(buffer), length(buffer)))
+  GC.@preserve buffer AdaBoostModel(ccall((:DeserializeAdaBoostModelPtr, adaboostLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), pointer(buffer), length(buffer)))
 end
 end # module
 

--- a/src/approx_kfn.jl
+++ b/src/approx_kfn.jl
@@ -35,14 +35,14 @@ end
 # Serialize a model to the given stream.
 function serializeApproxKFNModel(stream::IO, model::ApproxKFNModel)
   buf_len = UInt[0]
-  buf_ptr = ccall((:SerializeApproxKFNModelPtr, approx_kfnLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, Base.pointer(buf_len))
+  buf_ptr = ccall((:SerializeApproxKFNModelPtr, approx_kfnLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, pointer(buf_len))
   buf = Base.unsafe_wrap(Vector{UInt8}, buf_ptr, buf_len[1]; own=true)
   write(stream, buf)
 end
 # Deserialize a model from the given stream.
 function deserializeApproxKFNModel(stream::IO)::ApproxKFNModel
   buffer = read(stream)
-  ApproxKFNModel(ccall((:DeserializeApproxKFNModelPtr, approx_kfnLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), Base.pointer(buffer), length(buffer)))
+  GC.@preserve buffer ApproxKFNModel(ccall((:DeserializeApproxKFNModelPtr, approx_kfnLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), pointer(buffer), length(buffer)))
 end
 end # module
 

--- a/src/bayesian_linear_regression.jl
+++ b/src/bayesian_linear_regression.jl
@@ -35,14 +35,14 @@ end
 # Serialize a model to the given stream.
 function serializeBayesianLinearRegression(stream::IO, model::BayesianLinearRegression)
   buf_len = UInt[0]
-  buf_ptr = ccall((:SerializeBayesianLinearRegressionPtr, bayesian_linear_regressionLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, Base.pointer(buf_len))
+  buf_ptr = ccall((:SerializeBayesianLinearRegressionPtr, bayesian_linear_regressionLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, pointer(buf_len))
   buf = Base.unsafe_wrap(Vector{UInt8}, buf_ptr, buf_len[1]; own=true)
   write(stream, buf)
 end
 # Deserialize a model from the given stream.
 function deserializeBayesianLinearRegression(stream::IO)::BayesianLinearRegression
   buffer = read(stream)
-  BayesianLinearRegression(ccall((:DeserializeBayesianLinearRegressionPtr, bayesian_linear_regressionLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), Base.pointer(buffer), length(buffer)))
+  GC.@preserve buffer BayesianLinearRegression(ccall((:DeserializeBayesianLinearRegressionPtr, bayesian_linear_regressionLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), pointer(buffer), length(buffer)))
 end
 end # module
 

--- a/src/cf.jl
+++ b/src/cf.jl
@@ -35,14 +35,14 @@ end
 # Serialize a model to the given stream.
 function serializeCFModel(stream::IO, model::CFModel)
   buf_len = UInt[0]
-  buf_ptr = ccall((:SerializeCFModelPtr, cfLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, Base.pointer(buf_len))
+  buf_ptr = ccall((:SerializeCFModelPtr, cfLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, pointer(buf_len))
   buf = Base.unsafe_wrap(Vector{UInt8}, buf_ptr, buf_len[1]; own=true)
   write(stream, buf)
 end
 # Deserialize a model from the given stream.
 function deserializeCFModel(stream::IO)::CFModel
   buffer = read(stream)
-  CFModel(ccall((:DeserializeCFModelPtr, cfLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), Base.pointer(buffer), length(buffer)))
+  GC.@preserve buffer CFModel(ccall((:DeserializeCFModelPtr, cfLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), pointer(buffer), length(buffer)))
 end
 end # module
 

--- a/src/decision_stump.jl
+++ b/src/decision_stump.jl
@@ -35,14 +35,14 @@ end
 # Serialize a model to the given stream.
 function serializeDSModel(stream::IO, model::DSModel)
   buf_len = UInt[0]
-  buf_ptr = ccall((:SerializeDSModelPtr, decision_stumpLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, Base.pointer(buf_len))
+  buf_ptr = ccall((:SerializeDSModelPtr, decision_stumpLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, pointer(buf_len))
   buf = Base.unsafe_wrap(Vector{UInt8}, buf_ptr, buf_len[1]; own=true)
   write(stream, buf)
 end
 # Deserialize a model from the given stream.
 function deserializeDSModel(stream::IO)::DSModel
   buffer = read(stream)
-  DSModel(ccall((:DeserializeDSModelPtr, decision_stumpLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), Base.pointer(buffer), length(buffer)))
+  GC.@preserve DSModel(ccall((:DeserializeDSModelPtr, decision_stumpLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), pointer(buffer), length(buffer)))
 end
 end # module
 

--- a/src/decision_tree.jl
+++ b/src/decision_tree.jl
@@ -35,14 +35,14 @@ end
 # Serialize a model to the given stream.
 function serializeDecisionTreeModel(stream::IO, model::DecisionTreeModel)
   buf_len = UInt[0]
-  buf_ptr = ccall((:SerializeDecisionTreeModelPtr, decision_treeLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, Base.pointer(buf_len))
+  buf_ptr = ccall((:SerializeDecisionTreeModelPtr, decision_treeLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, pointer(buf_len))
   buf = Base.unsafe_wrap(Vector{UInt8}, buf_ptr, buf_len[1]; own=true)
   write(stream, buf)
 end
 # Deserialize a model from the given stream.
 function deserializeDecisionTreeModel(stream::IO)::DecisionTreeModel
   buffer = read(stream)
-  DecisionTreeModel(ccall((:DeserializeDecisionTreeModelPtr, decision_treeLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), Base.pointer(buffer), length(buffer)))
+  GC.@preserve buffer DecisionTreeModel(ccall((:DeserializeDecisionTreeModelPtr, decision_treeLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), pointer(buffer), length(buffer)))
 end
 end # module
 

--- a/src/det.jl
+++ b/src/det.jl
@@ -35,14 +35,14 @@ end
 # Serialize a model to the given stream.
 function serializeDTree(stream::IO, model::DTree)
   buf_len = UInt[0]
-  buf_ptr = ccall((:SerializeDTreePtr, detLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, Base.pointer(buf_len))
+  buf_ptr = ccall((:SerializeDTreePtr, detLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, pointer(buf_len))
   buf = Base.unsafe_wrap(Vector{UInt8}, buf_ptr, buf_len[1]; own=true)
   write(stream, buf)
 end
 # Deserialize a model from the given stream.
 function deserializeDTree(stream::IO)::DTree
   buffer = read(stream)
-  DTree(ccall((:DeserializeDTreePtr, detLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), Base.pointer(buffer), length(buffer)))
+  GC.@preserve buffer DTree(ccall((:DeserializeDTreePtr, detLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), pointer(buffer), length(buffer)))
 end
 end # module
 

--- a/src/fastmks.jl
+++ b/src/fastmks.jl
@@ -35,14 +35,14 @@ end
 # Serialize a model to the given stream.
 function serializeFastMKSModel(stream::IO, model::FastMKSModel)
   buf_len = UInt[0]
-  buf_ptr = ccall((:SerializeFastMKSModelPtr, fastmksLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, Base.pointer(buf_len))
+  buf_ptr = ccall((:SerializeFastMKSModelPtr, fastmksLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, pointer(buf_len))
   buf = Base.unsafe_wrap(Vector{UInt8}, buf_ptr, buf_len[1]; own=true)
   write(stream, buf)
 end
 # Deserialize a model from the given stream.
 function deserializeFastMKSModel(stream::IO)::FastMKSModel
   buffer = read(stream)
-  FastMKSModel(ccall((:DeserializeFastMKSModelPtr, fastmksLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), Base.pointer(buffer), length(buffer)))
+  GC.@preserve buffer FastMKSModel(ccall((:DeserializeFastMKSModelPtr, fastmksLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), pointer(buffer), length(buffer)))
 end
 end # module
 

--- a/src/gmm_generate.jl
+++ b/src/gmm_generate.jl
@@ -35,14 +35,14 @@ end
 # Serialize a model to the given stream.
 function serializeGMM(stream::IO, model::GMM)
   buf_len = UInt[0]
-  buf_ptr = ccall((:SerializeGMMPtr, gmm_generateLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, Base.pointer(buf_len))
+  buf_ptr = ccall((:SerializeGMMPtr, gmm_generateLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, pointer(buf_len))
   buf = Base.unsafe_wrap(Vector{UInt8}, buf_ptr, buf_len[1]; own=true)
   write(stream, buf)
 end
 # Deserialize a model from the given stream.
 function deserializeGMM(stream::IO)::GMM
   buffer = read(stream)
-  GMM(ccall((:DeserializeGMMPtr, gmm_generateLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), Base.pointer(buffer), length(buffer)))
+  GC.@preserve buffer GMM(ccall((:DeserializeGMMPtr, gmm_generateLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), pointer(buffer), length(buffer)))
 end
 end # module
 

--- a/src/gmm_probability.jl
+++ b/src/gmm_probability.jl
@@ -35,14 +35,14 @@ end
 # Serialize a model to the given stream.
 function serializeGMM(stream::IO, model::GMM)
   buf_len = UInt[0]
-  buf_ptr = ccall((:SerializeGMMPtr, gmm_probabilityLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, Base.pointer(buf_len))
+  buf_ptr = ccall((:SerializeGMMPtr, gmm_probabilityLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, pointer(buf_len))
   buf = Base.unsafe_wrap(Vector{UInt8}, buf_ptr, buf_len[1]; own=true)
   write(stream, buf)
 end
 # Deserialize a model from the given stream.
 function deserializeGMM(stream::IO)::GMM
   buffer = read(stream)
-  GMM(ccall((:DeserializeGMMPtr, gmm_probabilityLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), Base.pointer(buffer), length(buffer)))
+  GC.@preserve buffer GMM(ccall((:DeserializeGMMPtr, gmm_probabilityLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), pointer(buffer), length(buffer)))
 end
 end # module
 

--- a/src/gmm_train.jl
+++ b/src/gmm_train.jl
@@ -35,14 +35,14 @@ end
 # Serialize a model to the given stream.
 function serializeGMM(stream::IO, model::GMM)
   buf_len = UInt[0]
-  buf_ptr = ccall((:SerializeGMMPtr, gmm_trainLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, Base.pointer(buf_len))
+  buf_ptr = ccall((:SerializeGMMPtr, gmm_trainLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, pointer(buf_len))
   buf = Base.unsafe_wrap(Vector{UInt8}, buf_ptr, buf_len[1]; own=true)
   write(stream, buf)
 end
 # Deserialize a model from the given stream.
 function deserializeGMM(stream::IO)::GMM
   buffer = read(stream)
-  GMM(ccall((:DeserializeGMMPtr, gmm_trainLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), Base.pointer(buffer), length(buffer)))
+  GC.@preserve buffer GMM(ccall((:DeserializeGMMPtr, gmm_trainLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), pointer(buffer), length(buffer)))
 end
 end # module
 

--- a/src/hmm_generate.jl
+++ b/src/hmm_generate.jl
@@ -35,14 +35,14 @@ end
 # Serialize a model to the given stream.
 function serializeHMMModel(stream::IO, model::HMMModel)
   buf_len = UInt[0]
-  buf_ptr = ccall((:SerializeHMMModelPtr, hmm_generateLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, Base.pointer(buf_len))
+  buf_ptr = ccall((:SerializeHMMModelPtr, hmm_generateLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, pointer(buf_len))
   buf = Base.unsafe_wrap(Vector{UInt8}, buf_ptr, buf_len[1]; own=true)
   write(stream, buf)
 end
 # Deserialize a model from the given stream.
 function deserializeHMMModel(stream::IO)::HMMModel
   buffer = read(stream)
-  HMMModel(ccall((:DeserializeHMMModelPtr, hmm_generateLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), Base.pointer(buffer), length(buffer)))
+  GC.@preserve buffer HMMModel(ccall((:DeserializeHMMModelPtr, hmm_generateLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), pointer(buffer), length(buffer)))
 end
 end # module
 

--- a/src/hmm_loglik.jl
+++ b/src/hmm_loglik.jl
@@ -35,14 +35,14 @@ end
 # Serialize a model to the given stream.
 function serializeHMMModel(stream::IO, model::HMMModel)
   buf_len = UInt[0]
-  buf_ptr = ccall((:SerializeHMMModelPtr, hmm_loglikLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, Base.pointer(buf_len))
+  buf_ptr = ccall((:SerializeHMMModelPtr, hmm_loglikLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, pointer(buf_len))
   buf = Base.unsafe_wrap(Vector{UInt8}, buf_ptr, buf_len[1]; own=true)
   write(stream, buf)
 end
 # Deserialize a model from the given stream.
 function deserializeHMMModel(stream::IO)::HMMModel
   buffer = read(stream)
-  HMMModel(ccall((:DeserializeHMMModelPtr, hmm_loglikLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), Base.pointer(buffer), length(buffer)))
+  GC.@preserve buffer HMMModel(ccall((:DeserializeHMMModelPtr, hmm_loglikLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), pointer(buffer), length(buffer)))
 end
 end # module
 

--- a/src/hmm_train.jl
+++ b/src/hmm_train.jl
@@ -35,14 +35,14 @@ end
 # Serialize a model to the given stream.
 function serializeHMMModel(stream::IO, model::HMMModel)
   buf_len = UInt[0]
-  buf_ptr = ccall((:SerializeHMMModelPtr, hmm_trainLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, Base.pointer(buf_len))
+  buf_ptr = ccall((:SerializeHMMModelPtr, hmm_trainLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, pointer(buf_len))
   buf = Base.unsafe_wrap(Vector{UInt8}, buf_ptr, buf_len[1]; own=true)
   write(stream, buf)
 end
 # Deserialize a model from the given stream.
 function deserializeHMMModel(stream::IO)::HMMModel
   buffer = read(stream)
-  HMMModel(ccall((:DeserializeHMMModelPtr, hmm_trainLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), Base.pointer(buffer), length(buffer)))
+  GC.@preserve buffer HMMModel(ccall((:DeserializeHMMModelPtr, hmm_trainLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), pointer(buffer), length(buffer)))
 end
 end # module
 

--- a/src/hmm_viterbi.jl
+++ b/src/hmm_viterbi.jl
@@ -35,14 +35,14 @@ end
 # Serialize a model to the given stream.
 function serializeHMMModel(stream::IO, model::HMMModel)
   buf_len = UInt[0]
-  buf_ptr = ccall((:SerializeHMMModelPtr, hmm_viterbiLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, Base.pointer(buf_len))
+  buf_ptr = ccall((:SerializeHMMModelPtr, hmm_viterbiLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, pointer(buf_len))
   buf = Base.unsafe_wrap(Vector{UInt8}, buf_ptr, buf_len[1]; own=true)
   write(stream, buf)
 end
 # Deserialize a model from the given stream.
 function deserializeHMMModel(stream::IO)::HMMModel
   buffer = read(stream)
-  HMMModel(ccall((:DeserializeHMMModelPtr, hmm_viterbiLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), Base.pointer(buffer), length(buffer)))
+  GC.@preserve buffer HMMModel(ccall((:DeserializeHMMModelPtr, hmm_viterbiLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), pointer(buffer), length(buffer)))
 end
 end # module
 

--- a/src/hoeffding_tree.jl
+++ b/src/hoeffding_tree.jl
@@ -35,14 +35,14 @@ end
 # Serialize a model to the given stream.
 function serializeHoeffdingTreeModel(stream::IO, model::HoeffdingTreeModel)
   buf_len = UInt[0]
-  buf_ptr = ccall((:SerializeHoeffdingTreeModelPtr, hoeffding_treeLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, Base.pointer(buf_len))
+  buf_ptr = ccall((:SerializeHoeffdingTreeModelPtr, hoeffding_treeLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, pointer(buf_len))
   buf = Base.unsafe_wrap(Vector{UInt8}, buf_ptr, buf_len[1]; own=true)
   write(stream, buf)
 end
 # Deserialize a model from the given stream.
 function deserializeHoeffdingTreeModel(stream::IO)::HoeffdingTreeModel
   buffer = read(stream)
-  HoeffdingTreeModel(ccall((:DeserializeHoeffdingTreeModelPtr, hoeffding_treeLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), Base.pointer(buffer), length(buffer)))
+  GC.@preserve buffer HoeffdingTreeModel(ccall((:DeserializeHoeffdingTreeModelPtr, hoeffding_treeLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), pointer(buffer), length(buffer)))
 end
 end # module
 

--- a/src/io.jl
+++ b/src/io.jl
@@ -90,8 +90,8 @@ function IOSetParamMat(paramName::String,
                         paramValue,
                         pointsAsRows::Bool)
   paramMat = to_matrix(paramValue, Float64)
-  ccall((:IO_SetParamMat, library), Nothing, (Cstring, Ptr{Float64}, Csize_t,
-      Csize_t, Bool), paramName, Base.pointer(paramMat), size(paramMat, 1),
+  GC.@preserve paramMat ccall((:IO_SetParamMat, library), Nothing, (Cstring, Ptr{Float64}, Csize_t,
+      Csize_t, Bool), paramName, pointer(paramMat), size(paramMat, 1),
       size(paramMat, 2), pointsAsRows);
 end
 
@@ -107,8 +107,8 @@ function IOSetParamUMat(paramName::String,
   end
 
   m = convert(Array{Csize_t, 2}, paramMat .- 1)
-  ccall((:IO_SetParamUMat, library), Nothing, (Cstring, Ptr{Csize_t}, Csize_t,
-      Csize_t, Bool), paramName, Base.pointer(m), size(paramValue, 1),
+  GC.@preserve m ccall((:IO_SetParamUMat, library), Nothing, (Cstring, Ptr{Csize_t}, Csize_t,
+      Csize_t, Bool), paramName, pointer(m), size(paramValue, 1),
       size(paramValue, 2), pointsAsRows);
 end
 
@@ -129,31 +129,31 @@ end
 function IOSetParam(paramName::String,
                      vector::Vector{Int})
   cint_vec = convert(Vector{Cint}, vector)
-  ccall((:IO_SetParamVectorInt, library), Nothing, (Cstring, Ptr{Cint},
-      Csize_t), paramName, Base.pointer(cint_vec), size(cint_vec, 1));
+  GC.@preserve cint_vec ccall((:IO_SetParamVectorInt, library), Nothing, (Cstring, Ptr{Cint},
+      Csize_t), paramName, pointer(cint_vec), size(cint_vec, 1));
 end
 
 function IOSetParam(paramName::String,
                      matWithInfo::Tuple{Array{Bool, 1}, Array{Float64, 2}},
                      pointsAsRows::Bool)
-  ccall((:IO_SetParamMatWithInfo, library), Nothing, (Cstring, Ptr{Bool},
+  GC.@preserve matWithInfo ccall((:IO_SetParamMatWithInfo, library), Nothing, (Cstring, Ptr{Bool},
       Ptr{Float64}, Int, Int, Bool), paramName,
-      Base.pointer(matWithInfo[1]), Base.pointer(matWithInfo[2]),
+      pointer(matWithInfo[1]), pointer(matWithInfo[2]),
       size(matWithInfo[2], 1), size(matWithInfo[2], 2), pointsAsRows);
 end
 
 function IOSetParamRow(paramName::String,
                         paramValue)
   paramVec = to_vector(paramValue, Float64)
-  ccall((:IO_SetParamRow, library), Nothing, (Cstring, Ptr{Float64}, Csize_t),
-      paramName, Base.pointer(paramVec), size(paramVec, 1));
+  GC.@preserve paramVec ccall((:IO_SetParamRow, library), Nothing, (Cstring, Ptr{Float64}, Csize_t),
+      paramName, pointer(paramVec), size(paramVec, 1));
 end
 
 function IOSetParamCol(paramName::String,
                         paramValue)
   paramVec = to_vector(paramValue, Float64)
-  ccall((:IO_SetParamCol, library), Nothing, (Cstring, Ptr{Float64}, Csize_t),
-      paramName, Base.pointer(paramVec), size(paramVec, 1));
+  GC.@preserve paramVec ccall((:IO_SetParamCol, library), Nothing, (Cstring, Ptr{Float64}, Csize_t),
+      paramName, pointer(paramVec), size(paramVec, 1));
 end
 
 function IOSetParamURow(paramName::String,
@@ -167,8 +167,8 @@ function IOSetParamURow(paramName::String,
   end
   m = convert(Array{Csize_t, 1}, paramVec .- 1)
 
-  ccall((:IO_SetParamURow, library), Nothing, (Cstring, Ptr{Csize_t}, Csize_t),
-      paramName, Base.pointer(m), size(paramValue, 1));
+  GC.@preserve m ccall((:IO_SetParamURow, library), Nothing, (Cstring, Ptr{Csize_t}, Csize_t),
+      paramName, pointer(m), size(paramValue, 1));
 end
 
 function IOSetParamUCol(paramName::String,
@@ -182,8 +182,8 @@ function IOSetParamUCol(paramName::String,
   end
   m = convert(Array{Csize_t, 1}, paramValue .- 1)
 
-  ccall((:IO_SetParamUCol, library), Nothing, (Cstring, Ptr{Csize_t}, Csize_t),
-      paramName, Base.pointer(m), size(paramValue, 1));
+  GC.@preserve m ccall((:IO_SetParamUCol, library), Nothing, (Cstring, Ptr{Csize_t}, Csize_t),
+      paramName, pointer(m), size(paramValue, 1));
 end
 
 function IOGetParamBool(paramName::String)

--- a/src/kde.jl
+++ b/src/kde.jl
@@ -35,14 +35,14 @@ end
 # Serialize a model to the given stream.
 function serializeKDEModel(stream::IO, model::KDEModel)
   buf_len = UInt[0]
-  buf_ptr = ccall((:SerializeKDEModelPtr, kdeLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, Base.pointer(buf_len))
+  buf_ptr = ccall((:SerializeKDEModelPtr, kdeLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, pointer(buf_len))
   buf = Base.unsafe_wrap(Vector{UInt8}, buf_ptr, buf_len[1]; own=true)
   write(stream, buf)
 end
 # Deserialize a model from the given stream.
 function deserializeKDEModel(stream::IO)::KDEModel
   buffer = read(stream)
-  KDEModel(ccall((:DeserializeKDEModelPtr, kdeLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), Base.pointer(buffer), length(buffer)))
+  GC.@preserve buffer KDEModel(ccall((:DeserializeKDEModelPtr, kdeLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), pointer(buffer), length(buffer)))
 end
 end # module
 

--- a/src/kfn.jl
+++ b/src/kfn.jl
@@ -35,14 +35,14 @@ end
 # Serialize a model to the given stream.
 function serializeKFNModel(stream::IO, model::KFNModel)
   buf_len = UInt[0]
-  buf_ptr = ccall((:SerializeKFNModelPtr, kfnLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, Base.pointer(buf_len))
+  buf_ptr = ccall((:SerializeKFNModelPtr, kfnLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, pointer(buf_len))
   buf = Base.unsafe_wrap(Vector{UInt8}, buf_ptr, buf_len[1]; own=true)
   write(stream, buf)
 end
 # Deserialize a model from the given stream.
 function deserializeKFNModel(stream::IO)::KFNModel
   buffer = read(stream)
-  KFNModel(ccall((:DeserializeKFNModelPtr, kfnLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), Base.pointer(buffer), length(buffer)))
+  GC.@preserve buffer KFNModel(ccall((:DeserializeKFNModelPtr, kfnLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), pointer(buffer), length(buffer)))
 end
 end # module
 

--- a/src/knn.jl
+++ b/src/knn.jl
@@ -35,14 +35,14 @@ end
 # Serialize a model to the given stream.
 function serializeKNNModel(stream::IO, model::KNNModel)
   buf_len = UInt[0]
-  buf_ptr = ccall((:SerializeKNNModelPtr, knnLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, Base.pointer(buf_len))
+  buf_ptr = ccall((:SerializeKNNModelPtr, knnLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, pointer(buf_len))
   buf = Base.unsafe_wrap(Vector{UInt8}, buf_ptr, buf_len[1]; own=true)
   write(stream, buf)
 end
 # Deserialize a model from the given stream.
 function deserializeKNNModel(stream::IO)::KNNModel
   buffer = read(stream)
-  KNNModel(ccall((:DeserializeKNNModelPtr, knnLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), Base.pointer(buffer), length(buffer)))
+  GC.@preserve buffer KNNModel(ccall((:DeserializeKNNModelPtr, knnLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), pointer(buffer), length(buffer)))
 end
 end # module
 

--- a/src/krann.jl
+++ b/src/krann.jl
@@ -35,14 +35,14 @@ end
 # Serialize a model to the given stream.
 function serializeRANNModel(stream::IO, model::RANNModel)
   buf_len = UInt[0]
-  buf_ptr = ccall((:SerializeRANNModelPtr, krannLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, Base.pointer(buf_len))
+  buf_ptr = ccall((:SerializeRANNModelPtr, krannLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, pointer(buf_len))
   buf = Base.unsafe_wrap(Vector{UInt8}, buf_ptr, buf_len[1]; own=true)
   write(stream, buf)
 end
 # Deserialize a model from the given stream.
 function deserializeRANNModel(stream::IO)::RANNModel
   buffer = read(stream)
-  RANNModel(ccall((:DeserializeRANNModelPtr, krannLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), Base.pointer(buffer), length(buffer)))
+  GC.@preserve buffer RANNModel(ccall((:DeserializeRANNModelPtr, krannLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), pointer(buffer), length(buffer)))
 end
 end # module
 

--- a/src/lars.jl
+++ b/src/lars.jl
@@ -35,14 +35,14 @@ end
 # Serialize a model to the given stream.
 function serializeLARS(stream::IO, model::LARS)
   buf_len = UInt[0]
-  buf_ptr = ccall((:SerializeLARSPtr, larsLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, Base.pointer(buf_len))
+  buf_ptr = ccall((:SerializeLARSPtr, larsLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, pointer(buf_len))
   buf = Base.unsafe_wrap(Vector{UInt8}, buf_ptr, buf_len[1]; own=true)
   write(stream, buf)
 end
 # Deserialize a model from the given stream.
 function deserializeLARS(stream::IO)::LARS
   buffer = read(stream)
-  LARS(ccall((:DeserializeLARSPtr, larsLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), Base.pointer(buffer), length(buffer)))
+  GC.@preserve buffer LARS(ccall((:DeserializeLARSPtr, larsLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), pointer(buffer), length(buffer)))
 end
 end # module
 

--- a/src/linear_regression.jl
+++ b/src/linear_regression.jl
@@ -35,14 +35,14 @@ end
 # Serialize a model to the given stream.
 function serializeLinearRegression(stream::IO, model::LinearRegression)
   buf_len = UInt[0]
-  buf_ptr = ccall((:SerializeLinearRegressionPtr, linear_regressionLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, Base.pointer(buf_len))
+  buf_ptr = ccall((:SerializeLinearRegressionPtr, linear_regressionLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, pointer(buf_len))
   buf = Base.unsafe_wrap(Vector{UInt8}, buf_ptr, buf_len[1]; own=true)
   write(stream, buf)
 end
 # Deserialize a model from the given stream.
 function deserializeLinearRegression(stream::IO)::LinearRegression
   buffer = read(stream)
-  LinearRegression(ccall((:DeserializeLinearRegressionPtr, linear_regressionLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), Base.pointer(buffer), length(buffer)))
+  GC.@preserve buffer LinearRegression(ccall((:DeserializeLinearRegressionPtr, linear_regressionLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), pointer(buffer), length(buffer)))
 end
 end # module
 

--- a/src/linear_svm.jl
+++ b/src/linear_svm.jl
@@ -35,14 +35,14 @@ end
 # Serialize a model to the given stream.
 function serializeLinearSVMModel(stream::IO, model::LinearSVMModel)
   buf_len = UInt[0]
-  buf_ptr = ccall((:SerializeLinearSVMModelPtr, linear_svmLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, Base.pointer(buf_len))
+  buf_ptr = ccall((:SerializeLinearSVMModelPtr, linear_svmLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, pointer(buf_len))
   buf = Base.unsafe_wrap(Vector{UInt8}, buf_ptr, buf_len[1]; own=true)
   write(stream, buf)
 end
 # Deserialize a model from the given stream.
 function deserializeLinearSVMModel(stream::IO)::LinearSVMModel
   buffer = read(stream)
-  LinearSVMModel(ccall((:DeserializeLinearSVMModelPtr, linear_svmLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), Base.pointer(buffer), length(buffer)))
+  GC.@preserve buffer LinearSVMModel(ccall((:DeserializeLinearSVMModelPtr, linear_svmLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), pointer(buffer), length(buffer)))
 end
 end # module
 

--- a/src/local_coordinate_coding.jl
+++ b/src/local_coordinate_coding.jl
@@ -35,14 +35,14 @@ end
 # Serialize a model to the given stream.
 function serializeLocalCoordinateCoding(stream::IO, model::LocalCoordinateCoding)
   buf_len = UInt[0]
-  buf_ptr = ccall((:SerializeLocalCoordinateCodingPtr, local_coordinate_codingLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, Base.pointer(buf_len))
+  buf_ptr = ccall((:SerializeLocalCoordinateCodingPtr, local_coordinate_codingLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, pointer(buf_len))
   buf = Base.unsafe_wrap(Vector{UInt8}, buf_ptr, buf_len[1]; own=true)
   write(stream, buf)
 end
 # Deserialize a model from the given stream.
 function deserializeLocalCoordinateCoding(stream::IO)::LocalCoordinateCoding
   buffer = read(stream)
-  LocalCoordinateCoding(ccall((:DeserializeLocalCoordinateCodingPtr, local_coordinate_codingLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), Base.pointer(buffer), length(buffer)))
+  GC.@preserve buffer LocalCoordinateCoding(ccall((:DeserializeLocalCoordinateCodingPtr, local_coordinate_codingLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), pointer(buffer), length(buffer)))
 end
 end # module
 

--- a/src/logistic_regression.jl
+++ b/src/logistic_regression.jl
@@ -35,14 +35,14 @@ end
 # Serialize a model to the given stream.
 function serializeLogisticRegression(stream::IO, model::LogisticRegression)
   buf_len = UInt[0]
-  buf_ptr = ccall((:SerializeLogisticRegressionPtr, logistic_regressionLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, Base.pointer(buf_len))
+  buf_ptr = ccall((:SerializeLogisticRegressionPtr, logistic_regressionLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, pointer(buf_len))
   buf = Base.unsafe_wrap(Vector{UInt8}, buf_ptr, buf_len[1]; own=true)
   write(stream, buf)
 end
 # Deserialize a model from the given stream.
 function deserializeLogisticRegression(stream::IO)::LogisticRegression
   buffer = read(stream)
-  LogisticRegression(ccall((:DeserializeLogisticRegressionPtr, logistic_regressionLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), Base.pointer(buffer), length(buffer)))
+  GC.@preserve buffer LogisticRegression(ccall((:DeserializeLogisticRegressionPtr, logistic_regressionLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), pointer(buffer), length(buffer)))
 end
 end # module
 

--- a/src/lsh.jl
+++ b/src/lsh.jl
@@ -35,14 +35,14 @@ end
 # Serialize a model to the given stream.
 function serializeLSHSearch(stream::IO, model::LSHSearch)
   buf_len = UInt[0]
-  buf_ptr = ccall((:SerializeLSHSearchPtr, lshLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, Base.pointer(buf_len))
+  buf_ptr = ccall((:SerializeLSHSearchPtr, lshLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, pointer(buf_len))
   buf = Base.unsafe_wrap(Vector{UInt8}, buf_ptr, buf_len[1]; own=true)
   write(stream, buf)
 end
 # Deserialize a model from the given stream.
 function deserializeLSHSearch(stream::IO)::LSHSearch
   buffer = read(stream)
-  LSHSearch(ccall((:DeserializeLSHSearchPtr, lshLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), Base.pointer(buffer), length(buffer)))
+  GC.@preserve buffer LSHSearch(ccall((:DeserializeLSHSearchPtr, lshLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), pointer(buffer), length(buffer)))
 end
 end # module
 

--- a/src/nbc.jl
+++ b/src/nbc.jl
@@ -35,14 +35,14 @@ end
 # Serialize a model to the given stream.
 function serializeNBCModel(stream::IO, model::NBCModel)
   buf_len = UInt[0]
-  buf_ptr = ccall((:SerializeNBCModelPtr, nbcLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, Base.pointer(buf_len))
+  buf_ptr = ccall((:SerializeNBCModelPtr, nbcLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, pointer(buf_len))
   buf = Base.unsafe_wrap(Vector{UInt8}, buf_ptr, buf_len[1]; own=true)
   write(stream, buf)
 end
 # Deserialize a model from the given stream.
 function deserializeNBCModel(stream::IO)::NBCModel
   buffer = read(stream)
-  NBCModel(ccall((:DeserializeNBCModelPtr, nbcLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), Base.pointer(buffer), length(buffer)))
+  GC.@preserve buffer NBCModel(ccall((:DeserializeNBCModelPtr, nbcLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), pointer(buffer), length(buffer)))
 end
 end # module
 

--- a/src/perceptron.jl
+++ b/src/perceptron.jl
@@ -35,14 +35,14 @@ end
 # Serialize a model to the given stream.
 function serializePerceptronModel(stream::IO, model::PerceptronModel)
   buf_len = UInt[0]
-  buf_ptr = ccall((:SerializePerceptronModelPtr, perceptronLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, Base.pointer(buf_len))
+  buf_ptr = ccall((:SerializePerceptronModelPtr, perceptronLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, pointer(buf_len))
   buf = Base.unsafe_wrap(Vector{UInt8}, buf_ptr, buf_len[1]; own=true)
   write(stream, buf)
 end
 # Deserialize a model from the given stream.
 function deserializePerceptronModel(stream::IO)::PerceptronModel
   buffer = read(stream)
-  PerceptronModel(ccall((:DeserializePerceptronModelPtr, perceptronLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), Base.pointer(buffer), length(buffer)))
+  GC.@preserve buffer PerceptronModel(ccall((:DeserializePerceptronModelPtr, perceptronLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), pointer(buffer), length(buffer)))
 end
 end # module
 

--- a/src/preprocess_scale.jl
+++ b/src/preprocess_scale.jl
@@ -35,14 +35,14 @@ end
 # Serialize a model to the given stream.
 function serializeScalingModel(stream::IO, model::ScalingModel)
   buf_len = UInt[0]
-  buf_ptr = ccall((:SerializeScalingModelPtr, preprocess_scaleLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, Base.pointer(buf_len))
+  buf_ptr = ccall((:SerializeScalingModelPtr, preprocess_scaleLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, pointer(buf_len))
   buf = Base.unsafe_wrap(Vector{UInt8}, buf_ptr, buf_len[1]; own=true)
   write(stream, buf)
 end
 # Deserialize a model from the given stream.
 function deserializeScalingModel(stream::IO)::ScalingModel
   buffer = read(stream)
-  ScalingModel(ccall((:DeserializeScalingModelPtr, preprocess_scaleLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), Base.pointer(buffer), length(buffer)))
+  GC.@preserve buffer ScalingModel(ccall((:DeserializeScalingModelPtr, preprocess_scaleLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), pointer(buffer), length(buffer)))
 end
 end # module
 

--- a/src/random_forest.jl
+++ b/src/random_forest.jl
@@ -35,14 +35,14 @@ end
 # Serialize a model to the given stream.
 function serializeRandomForestModel(stream::IO, model::RandomForestModel)
   buf_len = UInt[0]
-  buf_ptr = ccall((:SerializeRandomForestModelPtr, random_forestLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, Base.pointer(buf_len))
+  buf_ptr = ccall((:SerializeRandomForestModelPtr, random_forestLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, pointer(buf_len))
   buf = Base.unsafe_wrap(Vector{UInt8}, buf_ptr, buf_len[1]; own=true)
   write(stream, buf)
 end
 # Deserialize a model from the given stream.
 function deserializeRandomForestModel(stream::IO)::RandomForestModel
   buffer = read(stream)
-  RandomForestModel(ccall((:DeserializeRandomForestModelPtr, random_forestLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), Base.pointer(buffer), length(buffer)))
+  GC.@preserve buffer RandomForestModel(ccall((:DeserializeRandomForestModelPtr, random_forestLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), pointer(buffer), length(buffer)))
 end
 end # module
 

--- a/src/softmax_regression.jl
+++ b/src/softmax_regression.jl
@@ -35,14 +35,14 @@ end
 # Serialize a model to the given stream.
 function serializeSoftmaxRegression(stream::IO, model::SoftmaxRegression)
   buf_len = UInt[0]
-  buf_ptr = ccall((:SerializeSoftmaxRegressionPtr, softmax_regressionLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, Base.pointer(buf_len))
+  buf_ptr = ccall((:SerializeSoftmaxRegressionPtr, softmax_regressionLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, pointer(buf_len))
   buf = Base.unsafe_wrap(Vector{UInt8}, buf_ptr, buf_len[1]; own=true)
   write(stream, buf)
 end
 # Deserialize a model from the given stream.
 function deserializeSoftmaxRegression(stream::IO)::SoftmaxRegression
   buffer = read(stream)
-  SoftmaxRegression(ccall((:DeserializeSoftmaxRegressionPtr, softmax_regressionLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), Base.pointer(buffer), length(buffer)))
+  GC.@preserve buffer SoftmaxRegression(ccall((:DeserializeSoftmaxRegressionPtr, softmax_regressionLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), pointer(buffer), length(buffer)))
 end
 end # module
 

--- a/src/sparse_coding.jl
+++ b/src/sparse_coding.jl
@@ -35,14 +35,14 @@ end
 # Serialize a model to the given stream.
 function serializeSparseCoding(stream::IO, model::SparseCoding)
   buf_len = UInt[0]
-  buf_ptr = ccall((:SerializeSparseCodingPtr, sparse_codingLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, Base.pointer(buf_len))
+  buf_ptr = ccall((:SerializeSparseCodingPtr, sparse_codingLibrary), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt}), model.ptr, pointer(buf_len))
   buf = Base.unsafe_wrap(Vector{UInt8}, buf_ptr, buf_len[1]; own=true)
   write(stream, buf)
 end
 # Deserialize a model from the given stream.
 function deserializeSparseCoding(stream::IO)::SparseCoding
   buffer = read(stream)
-  SparseCoding(ccall((:DeserializeSparseCodingPtr, sparse_codingLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), Base.pointer(buffer), length(buffer)))
+  GC.@preserve buffer SparseCoding(ccall((:DeserializeSparseCodingPtr, sparse_codingLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), pointer(buffer), length(buffer)))
 end
 end # module
 


### PR DESCRIPTION
I'm not sure this is the true fix but this is the correct thing to do when using `pointer()`. Also, I ran tests locally a couple of times and no segfaults so hopefully...